### PR TITLE
[Blocked] Swapped out dates and removed links 

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,8 +241,8 @@
             </a>
           </li>
           <li class="footer__link-item">
-            <a class="footer__link" target="_new" href="https://medium.com/triton-engineering-student-council">
-              <i class="fab fa-medium"></i>
+            <a class="footer__link" target="_new" href="https://instagram.com/ucsdtesc/">
+              <i class="fab fa-instagram"></i>
             </a>
           </li>
           <li class="footer__link-item">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <meta property="og:image:type" content="image/png" />
   <meta name="theme-color" content="#75C8DD" />
   <meta name="description" content="Official Website of SD Hacks" />
-  <meta name="keywords" content="SD Hacks, 2019, SD Hacks 2019, hackathon, UCSD, UC, University of California San Diego, San Diego" />
+  <meta name="keywords" content="SD Hacks, 2020, SD Hacks 2020, hackathon, UCSD, UC, University of California San Diego, San Diego" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
   <meta name="description" content="SDHacks, UC San Diego's Annual Collegiate Hackathon">
@@ -40,10 +40,10 @@
               <a class="nav__link" href="#companies">Previous Sponsors</a>
             </li>
             <li class="nav__link-item">
-              <a class="nav__link" href="https://sdhacks2018.devpost.com/" target="_blank">2018 Projects</a>
+              <a class="nav__link" href="https://sd-hacks-2019.devpost.com/" target="_blank">2019 Projects</a>
             </li>
             <li class="nav__link-item">
-              <a class="nav__link" href="http://2018.sdhacks.io" target="_blank">2018 Page</a>
+              <a class="nav__link" href="http://2019.sdhacks.io" target="_blank">2019 Page</a>
             </li>
             <li class="nav__link-item">
               <a class="nav__link" href="#contact">Contact</a>
@@ -66,10 +66,10 @@
             <a class="hamburger__link" href="#companies">Previous Sponsors</a>
           </li>
           <li class="hamburger__link-item">
-            <a class="hamburger__link" href="https://sdhacks2018.devpost.com" target="_blank">2018 Projects</a>
+            <a class="hamburger__link" href="https://sdhacks2019.devpost.com" target="_blank">2019 Projects</a>
           </li>
           <li class="hamburger__link-item">
-            <a class="hamburger__link" href="http://2018.sdhacks.io" target="_blank">2018 Page</a>
+            <a class="hamburger__link" href="http://2019.sdhacks.io" target="_blank">2019 Page</a>
           </li>
           <li class="hamburger__link-item">
             <a class="hamburger__link" href="#contact">Contact</a>
@@ -86,8 +86,8 @@
               Build your dreams
             </div>
             <div class="hero__location">
-             Oct 25-27, 2019 @ 
-             <a href="https://www.google.com/maps/place/RIMAC+Arena/@32.8852802,-117.2413763,17z/data=!3m1!4b1!4m5!3m4!1s0x80dc06d869a3c4bd:0x5986425d4b318e9f!8m2!3d32.8852757!4d-117.2391823" target="_blank" class="hero__location-link"> RIMAC Arena, UCSD </a> 
+             Winter 2021 @
+             <a href="https://www.google.com/maps/place/UC+San+Diego,+Gilman+Drive,+La+Jolla,+CA/@32.8851159,-117.2413536,17z/data=!4m5!3m4!1s0x80dc06c4414caf4f:0xefb6aafc89913ea7!8m2!3d32.8800604!4d-117.2340135" target="_blank" class="hero__location-link"> UC San Diego </a> 
             </div>
             <p class="hero__desc">
               UC San Diego's annual collegiate hackathon is back with more than ever before. Stay tuned by signing up for the mailing list below!
@@ -117,9 +117,7 @@
     <section class="companies" id="companies">
       <div class="container">
         <h1 class="mb-3">Previous Sponsors</h1>
-        <div class="companies__contact mb-5 col-12"> Interested in sponsoring? Check out our 
-          <a href="./assets/pdf/SDHacks2019SponsorProposal.pdf" class="companies__contact-link" target="_blank">Sponsorship Packet</a> 
-          and email us at 
+        <div class="companies__contact mb-5 col-12"> Interested in sponsoring? Email us at 
           <a href="mailto:sponsor@tesc.ucsd.edu" class="companies__contact-link"> sponsor@tesc.ucsd.edu </a></div>
         <div class="companies__grid row">
           <div class="col-lg-3 col-md-4">


### PR DESCRIPTION
## Changes 
- Swapped out navbar hrefs with 2019 links 
- Swapped out `Oct 25-27, 2019 @ RIMAC Arena, UCSD` w/ `Winter 2021 @ UC San Diego` on the landing page 
- Removed outdated 2018 sponsorship packet href 

## To do
- [ ] Deploy 2019.sdhacks.io 

I swapped out the `2018.sdhacks.io` href with `2019.sdhacks.io` but the 2019 site isn't deployed yet 
